### PR TITLE
user can now update/change their current password; test cases included

### DIFF
--- a/ProjectSourceCode/src/views/pages/profile.hbs
+++ b/ProjectSourceCode/src/views/pages/profile.hbs
@@ -66,7 +66,38 @@
                    <button type="submit">Save Preferences</button>
                </form>
            </div>
-           <button id="delete-account-button">Delete Account</button>
+           <button class="my-2 btn btn-secondary" id="delete-account-button">Delete Account</button>
+
+           {{!-- change password --}}
+           <button class="my-2 btn btn-primary" id="change-password-button" data-bs-toggle="modal" data-bs-target="#passwordChangeModal">Change Password</button>
+           <div class="modal" id="passwordChangeModal" tabindex="-1" aria-labelledby="questionModal" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="questionModalLabel">Are you sure you want to change your password?</h5>
+                        </div>
+                        <div class="my-3" id="areYouSureButtons">
+                            <button type="button" class="btn btn-success" id="changePassBtn">Yes</button>
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Naur</button>
+                        </div>
+                        <div class="modal-body" style="display: none;" id="passwordPromptModal">
+                            <form id="questionForm">
+                                <div class="mb-3">
+                                    <label class="form-label" for="currentPass">Current Pasword</label>
+                                    <input type="password" class="form-control" id="currentPass" >
+
+                                    <label class="form-label" for="newPass">New Pasword</label>
+                                    <input type="password" class="form-control" id="newPass" >
+                                </div>
+                            </form>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                <button type="button" class="btn btn-primary" id="submitChangedPassword">Set new password</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+           </div>
        </div>
    </div>
 
@@ -134,6 +165,55 @@
             .catch(error => console.error("Error:", error));
         }
     });
+
+    // change password JS
+    document.getElementById('submitChangedPassword').addEventListener('click', () => {
+        const currentPass = document.getElementById('currentPass').value;
+        const newPass = document.getElementById('newPass').value;
+        
+        if(currentPass && newPass) {
+            console.log('Current Pass:', currentPass);
+            console.log('New Pass:', newPass);
+            // send change password to backend
+            fetch('/changePassword', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ currentPass, newPass }),
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert("Your password has been changed!");
+                    window.location.href = '/profile';
+                } else {
+                    alert(data.message || "Something went wrong with changing your password.");
+                }
+            })
+            .catch(error => console.error("Error:", error));
+        } else {
+            alert("Please answer both prompts.");
+        }
+    });
+    // reset modal 
+    function resetModelState() {
+        document.getElementById("passwordPromptModal").style.display = "none";
+        document.getElementById("areYouSureButtons").style.display = "block";
+
+        document.getElementById('currentPass').value = '';
+        document.getElementById('newPass').value = '';
+    }
+    // event listeners for when the user presses the close button
+    document.querySelectorAll('[data-bs-dismiss="modal"]').forEach(button => {
+        button.addEventListener('click', resetModelState);
+    });
+    // show the modal form if yes is clicked 
+    document.getElementById("changePassBtn").addEventListener('click', () => {
+        document.getElementById("passwordPromptModal").style.display = "block";
+        document.getElementById("areYouSureButtons").style.display = "none";
+    });
+
 </script>
 
 


### PR DESCRIPTION
I spent the last few days creating a interactive setting of changing your password.  I will have a walk-through step to explain the code.

1) In the Profile page, you can notice that there is a new button at the bottom called 'Change password'. Once clicked, it will bring you a series of bootstrap's modals. The first is a question asking whether you are sure if you would like to continue to change your password. If the request is confirmed, then it displays a form asking for your current password and your new password.

2) Once final submission button is clicked, a JS function sends a API request to the backend server using the url '/changePassword' with the following passwords. In the API itself, it receives the passwords and also grabs the username that is created in session when the user logs in. Next the programs goes through another series of authentication, first by checking if the username exists, next if the current password is the same as the one logged into the database. Then finally it updates the password if all else is well.

3) There are two additional test cases added into the server.spec.js file to demonstrate the authentication abilities of the change_password API. There are more test cases that could be included in a more later update.